### PR TITLE
Create directories recursively

### DIFF
--- a/lib/clientlib.js
+++ b/lib/clientlib.js
@@ -407,7 +407,7 @@ function processItem(item, options, processDone) {
 
         // create directories separately or it will be copied recursively
         if (fs.lstatSync(fileItem.src).isDirectory()) {
-          fs.mkdir(fileItem.dest, copyDone);
+          fs.mkdir(fileItem.dest, { recursive: true }, copyDone);
         } else {
           fse.copy(fileItem.src, fileItem.dest, copyDone);
         }


### PR DESCRIPTION
With the following config:

```js
module.exports = {
  // ...
  libs: {
    // ...
    assets: {
      js: ['./dist/**/*.js'],
      css: ['./dist/**/*.css'],
      resources: {
        cwd: './dist/',
        flatten: false,
        files: ['**/!(*.css|*.html|*.js|*.map)']
      }
    }
  }
};
```

and the following file structure:

```
dist/
  images/
    test.png
  test.css
  test.html
  test.js
  test.js.map
```

I receive the error

```
(node:22760) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, mkdir '../ui.apps/src/main/content/jcr_root/apps/project-name/clientlibs/project-name/resources/images'
(node:22760) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:22760) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Creating the clientlib directories recursively should resolve this problem.