### PR TITLE
Fix failing tests (on windows) caused by newline issue between *nix and windows

### DIFF
--- a/test/TestCase.test.js
+++ b/test/TestCase.test.js
@@ -64,8 +64,8 @@ describe("Test output", function() {
             assert.ok(fileExists(resultFile), "file does not exist in result: " + subFilePath);
 
             if (!fs.lstatSync(expectedFile).isDirectory()) {
-              var result = fs.readFileSync(resultFile, "utf-8");
-              var expected = fs.readFileSync(expectedFile, "utf-8");
+              var result = fs.readFileSync(resultFile, "utf-8").replace(/\r\n/g, "\n");
+              var expected = fs.readFileSync(expectedFile, "utf-8").replace(/\r\n/g, "\n");
 
               assert.equal(result, expected, "content of " + subFilePath + " is not expected");
             }


### PR DESCRIPTION
Failing tests are caused by EOL issues between windows and *nix. 
This issues is resolved by replacing \r\n (windows EOL) with \n (unix EOL)