### PR TITLE
Add `asset.ignore` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The following can be configured:
       * `dest` {String} - destination relative to the clientlib folder including base
   * `cwd` {String} - change working directory (relative to the context / global `cwd` option); only available with glob pattern
   * `flatten` {Boolean} - using file's basename instead of folder hierarchy; default true; only available with glob pattern
+  * `ignore` `{String|Array<String>}` - glob pattern or array of glob patterns for matches to exclude
 
 For an glob example see example section below.
 

--- a/lib/clientlib.js
+++ b/lib/clientlib.js
@@ -294,6 +294,9 @@ function normalizeAssets(clientLibPath, assets) {
     if (asset.cwd) {
       globOptions.cwd = asset.cwd;
     }
+    if (asset.ignore) {
+      globOptions.ignore = asset.ignore;
+    }
 
     asset.files.forEach(function (file) {
       var fileItem = file;

--- a/test/clientlib.config.js
+++ b/test/clientlib.config.js
@@ -238,6 +238,17 @@ module.exports = {
                     "src/frontend/resources/template.html"
                 ]
             }
+        },
+        {
+            name: "test.base.apps.ignoreOption",
+            assets: {
+                js: {
+                    cwd: "src/frontend/js",
+                    flatten: false,
+                    files: ["**/*"],
+                    ignore: ["**/*.min.js", "**/*.min.js.map"]
+                }
+            }
         }
     ]
 };

--- a/test/expected/clientlibs-root/test.base.apps.ignoreOption/js.txt
+++ b/test/expected/clientlibs-root/test.base.apps.ignoreOption/js.txt
@@ -1,0 +1,4 @@
+#base=js
+
+app.js
+libs/mylib.js

--- a/test/expected/clientlibs-root/test.base.apps.ignoreOption/js/app.js
+++ b/test/expected/clientlibs-root/test.base.apps.ignoreOption/js/app.js
@@ -1,0 +1,5 @@
+
+"use strict";
+var Test = function() {
+  this.test = "test";
+};

--- a/test/expected/clientlibs-root/test.base.apps.ignoreOption/js/libs/mylib.js
+++ b/test/expected/clientlibs-root/test.base.apps.ignoreOption/js/libs/mylib.js
@@ -1,0 +1,6 @@
+
+"use strict";
+var MyLib = function() {
+  this.test = "MyLib";
+};
+//# sourceMappingURL=mylib.js.map


### PR DESCRIPTION
Hi,

Would you be open to an `ignore` options for assets? This would e.g. simplify copying entire directories except for a few files, as it wouldn't be required to write a complicated glob pattern for that.

The value of the `ignore` option can simply be passed to functions of the `glob` module (see https://github.com/isaacs/node-glob#options).