### PR TITLE
allow 'replaces' as a property of clientLibDirectoryFields

### DIFF
--- a/lib/clientlib.js
+++ b/lib/clientlib.js
@@ -49,7 +49,7 @@ var SERIALIZATION_FORMAT_SLING_XML = "slingxml";
  * List of fields to be evaluated for being added to the {@code cq:ClientLibraryFolder} file descriptor
  * @type {String[]}
  */
-var clientLibDirectoryFields = ["embed", "dependencies", "cssProcessor", "jsProcessor", "allowProxy", "longCacheKey"];
+var clientLibDirectoryFields = ["embed", "dependencies", "cssProcessor", "jsProcessor", "allowProxy", "longCacheKey","replaces"];
 
 /**
  * List of source file extensions which AEM is able to merge and provide as `.js` or `.css` client-side library

--- a/lib/clientlib.js
+++ b/lib/clientlib.js
@@ -49,7 +49,7 @@ var SERIALIZATION_FORMAT_SLING_XML = "slingxml";
  * List of fields to be evaluated for being added to the {@code cq:ClientLibraryFolder} file descriptor
  * @type {String[]}
  */
-var clientLibDirectoryFields = ["embed", "dependencies", "cssProcessor", "jsProcessor", "allowProxy", "longCacheKey","replaces"];
+var clientLibDirectoryFields = ["embed", "dependencies", "cssProcessor", "jsProcessor", "allowProxy", "longCacheKey","replaces","disableIfReplacing"];
 
 /**
  * List of source file extensions which AEM is able to merge and provide as `.js` or `.css` client-side library


### PR DESCRIPTION
allow 'replaces' as a property of clientLibDirectoryFields