### PR TITLE
Added option to filter out duplicated entry files

### DIFF
--- a/lib/clientlib.js
+++ b/lib/clientlib.js
@@ -381,10 +381,23 @@ function normalizeAssets(clientLibPath, assets) {
       }
     });
 
+    mapping = removeDuplicates(mapping, 'src');
+
     asset.files = mapping;
   });
 
   return list;
+}
+
+/**
+ * Removes duplicates in array of Objects based on the provided key
+ * From: https://firstclassjs.com/remove-duplicate-objects-from-javascript-array-how-to-performance-comparison/
+ * @param {Array} array - array of Objects that will be filtered
+ * @param {String} key - key that will be used for filter comparison
+ */
+function removeDuplicates(array, key) {
+  let lookup = new Set();
+  return array.filter(obj => !lookup.has(obj[key]) && lookup.add(obj[key]));
 }
 
 /**
@@ -409,7 +422,7 @@ function processItem(item, options, processDone) {
     // create clientlib directory
     fse.mkdirsSync(clientLibPath);
 
-    var serializationFormat = (item.serializationFormat === SERIALIZATION_FORMAT_XML) ? SERIALIZATION_FORMAT_XML 
+    var serializationFormat = (item.serializationFormat === SERIALIZATION_FORMAT_XML) ? SERIALIZATION_FORMAT_XML
                             : (item.serializationFormat === SERIALIZATION_FORMAT_SLING_XML) ? SERIALIZATION_FORMAT_SLING_XML
                             : SERIALIZATION_FORMAT_JSON;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aem-clientlib-generator",
-  "version": "1.6.0",
+  "version": "1.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aem-clientlib-generator",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Creates configuration files for AEM ClientLibs and synchronizes assets.",
   "author": {
     "name": "pro!vision GmbH",

--- a/test/clientlib.config.js
+++ b/test/clientlib.config.js
@@ -99,6 +99,7 @@ module.exports = {
                     flatten: false, // remove this option if you like a flat list of files in your clientlib
                     cwd: "src/frontend/js/", // change working directory (will be stripped from destination)
                     files: [
+                        "**/app.js", // this file should be included only once
                         "**/*.js", // match all js files recursively
                         "**/*.js.map"
                     ]


### PR DESCRIPTION
This should allow for ordering files in the `js.txt` and `css.txt`.
When specifying glob patters some entries might be duplicated and it load order is driven by the file name and folder structure.

So this config:
```js
assets: { js: { files: ['dist.code/js/**/vendors.js', 'dist.code/js/**/*.js'] }, }
```
will create this output
```txt
#base=js

vendors.js
some-file.js
vendors.js
```

The expected output should look like this:
```txt
#base=js

vendors.js
some-file.js
```