### PR TITLE
Version Update - yargs

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "fs-extra": "9.0.1",
     "glob": "7.1.6",
     "lodash": "4.17.20",
-    "yargs": "15.4.1"
+    "yargs": "16.2.0"
   },
   "devDependencies": {
     "klaw": "3.0.0",


### PR DESCRIPTION
There is a security vulnerability(y18n) coming from yargs and updating to version 16.2.0 resolves the issue.