### PR TITLE
Issue #48: changed from commonjs to es6 modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 notifications:
   email: false
 node_js:
-  - "10.19.0"
+  - "16.18.0"
 cache:
   npm: true,
   directories:

--- a/lib/clientlib.js
+++ b/lib/clientlib.js
@@ -17,12 +17,12 @@
 
 "use strict";
 
-var async = require("async");
-var path = require("path");
-var _ = require("lodash");
-var fs = require("fs");
-var fse = require("fs-extra");
-var glob = require("glob");
+import async from "async";
+import path from "path";
+import _ from "lodash";
+import fs from "fs";
+import fse from "fs-extra";
+import glob from "glob";
 
 /**
  * JSON serialization format
@@ -538,6 +538,9 @@ function processItem(item, options, processDone) {
   });
 }
 
-module.exports = start;
-module.exports.removeClientLib = removeClientLib;
-module.exports.fileExists = fileExists;
+export default start;
+
+export {
+  removeClientLib,
+  fileExists,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.3",
-        "fs-extra": "9.0.1",
+        "fs-extra": "^9.0.1",
         "glob": "7.1.6",
         "lodash": "4.17.21",
         "yargs": "^16.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aem-clientlib-generator",
-  "version": "1.7.7",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aem-clientlib-generator",
-      "version": "1.7.7",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "async": "^3.2.3",
-    "fs-extra": "9.0.1",
+    "fs-extra": "^9.0.1",
     "glob": "7.1.6",
     "lodash": "4.17.21",
     "yargs": "^16.2.0"

--- a/package.json
+++ b/package.json
@@ -61,5 +61,6 @@
   "scripts": {
     "test": "mocha",
     "build": "bin/clientlib-cli.js test/clientlib.config.js --verbose"
-  }
+  },
+  "type": "module"
 }

--- a/test/clientlib.config.js
+++ b/test/clientlib.config.js
@@ -17,8 +17,12 @@
 
 "use strict";
 
-var path = require("path");
-module.exports = {
+import path from 'path';
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default {
 
     context: __dirname,
     clientLibRoot: path.resolve(__dirname, "result", "clientlibs-root"),


### PR DESCRIPTION
https://github.com/wcm-io-frontend/aem-clientlib-generator/issues/48

I have tested this change on two separate ui.frontend repositories and they seem to work.
I configured the repositories as follows:
- repo 1 had es6 modules system
- repo 2 had commonjs modules system (what the archetype generates today)

I did not encounter any issue with either build.

Also, yargs had to be updated itself to latest for esmodules support. The api has slightly changed as the imported item is no longer a singleton.