### PR TITLE
Disable yargs strict mode

### DIFF
--- a/bin/clientlib-cli.js
+++ b/bin/clientlib-cli.js
@@ -24,7 +24,7 @@ yargs
       type: "boolean",
       describe: "Prints more details"
     }
-  }).strict();
+  });
 
 var argv = yargs.argv;
 var configPath = path.resolve(process.cwd(), DEFAULT_FILE);


### PR DESCRIPTION
Latest version of yargs is otherwise too strict and does not allow to get first optoinal config path file argument