### PR TITLE
Remove lodash dependency

### DIFF
--- a/lib/clientlib.js
+++ b/lib/clientlib.js
@@ -19,7 +19,6 @@
 
 import async from "async";
 import path from "path";
-import _ from "lodash";
 import fs from "fs";
 import fse from "fs-extra";
 import { globSync, hasMagic } from "glob";
@@ -104,7 +103,7 @@ function removeClientLib(item, options, done) {
   var clientLibPath = path.join(item.path, item.name);
   var files = [];
 
-  if (_.isFunction(options)) {
+  if (typeof options === 'function') {
     done = options;
     options = {};
   }
@@ -136,7 +135,7 @@ function removeClientLib(item, options, done) {
  */
 function writeAssetTxt(clientLibPath, asset, options) {
 
-  if (!asset || !asset.type || !_.isArray(asset.files)) {
+  if (!asset || !asset.type || !Array.isArray(asset.files)) {
     return;
   }
   var outputFile = path.join(clientLibPath, asset.type + ".txt");
@@ -295,12 +294,12 @@ function getXmlOutputFile(item, serializationFormat) {
  */
 function start(itemList, options, done) {
 
-  if (_.isFunction(options)) {
+  if (typeof options === 'function') {
     done = options;
     options = {};
   }
 
-  if (!_.isArray(itemList)) {
+  if (!Array.isArray(itemList)) {
     itemList = [itemList];
   }
 
@@ -331,13 +330,13 @@ function normalizeAssets(clientLibPath, assets) {
   var list = assets;
 
   // transform object to array
-  if (!_.isArray(assets)) {
+  if (!Array.isArray(assets)) {
     list = [];
-    _.keys(assets).forEach(function (assetKey) {
+    Object.keys(assets).forEach(function (assetKey) {
       var assetItem = assets[assetKey];
 
       // check/transform short version
-      if (_.isArray(assetItem)) {
+      if (Array.isArray(assetItem)) {
         assetItem = {
           files: assetItem
         };
@@ -368,7 +367,7 @@ function normalizeAssets(clientLibPath, assets) {
       var fileItem = file;
 
       // convert simple syntax to object
-      if (_.isString(file)) {
+      if (typeof file === "string" || file instanceof String) {
         fileItem = {
           src: file
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "async": "^3.2.3",
         "fs-extra": "11.3.4",
         "glob": "13.0.6",
-        "lodash": "4.17.23",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -554,11 +553,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -1646,11 +1640,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "async": "^3.2.3",
     "fs-extra": "11.3.4",
     "glob": "13.0.6",
-    "lodash": "4.17.23",
     "yargs": "^18.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove lodash dependency as there are active npm audit warnings against it. I replaced its functionality with native JavaScript since it was so infrequently used.